### PR TITLE
fix `commentstring` option to be a valid uxntal comment

### DIFF
--- a/ftplugin/uxntal.vim
+++ b/ftplugin/uxntal.vim
@@ -1,1 +1,1 @@
-setlocal commentstring=(%s)
+setlocal commentstring=(\ %s\ )


### PR DESCRIPTION
Now `commentstring` option is a valid uxntal comment with spaces around comment contents

```
( comment contents )